### PR TITLE
fixed bug occurring when a line contains both a valid directive and a comment

### DIFF
--- a/src/Robot/RobotsTxt.php
+++ b/src/Robot/RobotsTxt.php
@@ -30,14 +30,15 @@ class RobotsTxt
     private function parseFile($robotFile)
     {
         $currentUserAgent = null;
-        foreach (explode( "\n", strtolower($robotFile)) as $line) {
+        
+        $withoutComments = preg_replace( '/#.*/', '', strtolower( $robotFile ) );
 
-            $line = preg_replace('![ \t]*#.*[ \t]*[\r\n]!', '', $line);
+        foreach (explode( "\n", $withoutComments ) as $line) {
             
             $parts = array_filter(array_map('trim', explode(':', $line)));
 
             //if we don't have a full rule or this is a comment..
-            if (count($parts) < 2 || strpos($line, '#') === 0) {
+            if (count($parts) < 2) {
                 continue;
             }
 


### PR DESCRIPTION
I found a bug when you have a line containing both a directive and a comment, like:

```
Disallow: /      #comment
```

My edit strips away the comment, in each line, before the explosion of the string on the double colon. In this way the explode(':', $line) is executed on this string:

```
Disallow: /      
```
