### PR TITLE
Fix user agents not being lowercased before being checked

### DIFF
--- a/src/Robot/Leaf.php
+++ b/src/Robot/Leaf.php
@@ -42,9 +42,11 @@ class Leaf
      * @param string $userAgent The user agent to check
      * @param bool $allowed Are they allowed
      */
-    public function addRule($userAgent, $allowed)
+    public function addRule($userAgents, $allowed)
     {
-        $this->rules[$userAgent] = $allowed;
+        foreach ($userAgents as $userAgent) {
+            $this->rules[$userAgent] = $allowed;
+        }
     }
 
     /**
@@ -55,10 +57,13 @@ class Leaf
      */
     public function allowed($userAgent, $urlParts)
     {
-        $ourRule = isset($this->rules[$userAgent]) ? $this->rules[$userAgent] : null;
-        $currentUrlPart = array_shift($urlParts);
+        $wildcardRule = isset($this->rules['*']) ? $this->rules['*'] : null;
+        $ourRuleForUserAgent = isset($this->rules[$userAgent]) ? $this->rules[$userAgent] : null;
+        $ourRule = $ourRuleForUserAgent === null ? $wildcardRule : $ourRuleForUserAgent;
 
+        $currentUrlPart = array_shift($urlParts);
         $theirRule = null;
+
         foreach ($this->children as $part => $leaf) {
 
             //convert our leaf into a regular expression, replacing * with regex non greedy wildcards

--- a/src/Robot/RobotsFile.php
+++ b/src/Robot/RobotsFile.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Tom
+ * Date: 11/10/2015
+ * Time: 9:15 PM
+ */
+
+namespace tomverran\Robot;
+
+
+class RobotsFile
+{
+    /**
+     * @var String[]
+     */
+    private $lines;
+
+    /**
+     * Construct this Robots file
+     * @param String $content
+     */
+    public function __construct($content)
+    {
+        $withoutComments = preg_replace( '/#.*/', '', strtolower($content));
+        foreach(explode("\n", $withoutComments) as $line) {
+            $lineParts = array_filter(array_map('trim', explode(':', $line)));
+            if (count($lineParts) == 2) {
+                $this->lines[] = $lineParts;
+            }
+        }
+    }
+
+    /**
+     * Get the first directive in the file
+     */
+    public function firstDirective()
+    {
+        return $this->lines[0][0];
+    }
+
+    public function firstDirectiveIs($args)
+    {
+        if (!$this->hasLines()) {
+            return false;
+        }
+        return in_array($this->firstDirective(), func_get_args());
+    }
+
+    /**
+     * Get the argument of the first directive,
+     * and shift the file to remove it
+     */
+    public function shiftArgument()
+    {
+        return array_shift($this->lines)[1];
+    }
+
+    /**
+     * Does this file have any remaining lines
+     * @return bool
+     */
+    public function hasLines()
+    {
+        return !empty($this->lines);
+    }
+}

--- a/src/Robot/RobotsTxt.php
+++ b/src/Robot/RobotsTxt.php
@@ -69,7 +69,7 @@ class RobotsTxt
     public function isAllowed($userAgent, $path)
     {
         $urlParts = array_filter(explode('/', $path));
-        $ret = $this->tree->allowed($userAgent, $urlParts);
+        $ret = $this->tree->allowed(strtolower($userAgent), $urlParts);
 
         if ($ret === null) {
             $ret = $this->tree->allowed('*', $urlParts);

--- a/tests/RobotTest.php
+++ b/tests/RobotTest.php
@@ -80,4 +80,12 @@ class RobotTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(self::getRobotsTxt('comment')->isAllowed('robot', '/comment'), 'lines with inline comments');
         $this->assertFalse(self::getRobotsTxt('comment')->isAllowed('robot', '/test'), 'lines following those with inline comments');
     }
+
+    /**
+     * This entire library should be case insensitive
+     */
+    public function testCapitalisedUserAgent()
+    {
+        $this->assertFalse(self::getRobotsTxt('multiUserAgent')->isAllowed('Googlebot', '/private/page.html'), 'Capitalised UA');
+    }
 } 

--- a/tests/RobotTest.php
+++ b/tests/RobotTest.php
@@ -88,4 +88,21 @@ class RobotTest extends PHPUnit_Framework_TestCase
     {
         $this->assertFalse(self::getRobotsTxt('multiUserAgent')->isAllowed('Googlebot', '/private/page.html'), 'Capitalised UA');
     }
+
+    /**
+     *
+     */
+    public function testMultipleConsecutiveUserAgents()
+    {
+        foreach(['UA', 'Googlebot', '*'] as $agent) {
+            $this->assertFalse(self::getRobotsTxt('multiUserAgent')->isAllowed($agent, '/private/page.html'), $agent);
+            $this->assertTrue(self::getRobotsTxt('multiUserAgent')->isAllowed($agent, '/'), $agent);
+        }
+    }
+
+    public function testMultipleNonConsecutiveUserAgents()
+    {
+        $this->assertFalse(self::getRobotsTxt('multiUserAgent')->isAllowed('robot2', '/some/other'));
+        $this->assertTrue(self::getRobotsTxt('multiUserAgent')->isAllowed('Googlebot', '/some/other'));
+    }
 } 

--- a/tests/files/multiUserAgent.txt
+++ b/tests/files/multiUserAgent.txt
@@ -1,0 +1,6 @@
+User-agent: *
+User-agent: UA
+User-agent: Googlebot
+Allow: /
+Disallow: /private/
+Disallow: /secret/page.html

--- a/tests/files/multiUserAgent.txt
+++ b/tests/files/multiUserAgent.txt
@@ -4,3 +4,6 @@ User-agent: Googlebot
 Allow: /
 Disallow: /private/
 Disallow: /secret/page.html
+User-agent: robot2
+Allow: /
+Disallow: /some/other/


### PR DESCRIPTION
This fixes #3

Culprits were
 - user agents with capital letters never working(!)
 - No support for multiple user agents with the same rules

Note this also removes an exception the library would throw,
invalid robots.txt files will now just result in isAllowed being true all the time

