### PR TITLE
Fix exact user-agent matches not always being chosen above partial matches

### DIFF
--- a/src/Robot/Record.php
+++ b/src/Robot/Record.php
@@ -38,4 +38,9 @@ class Record
     {
         return !$this->ua->getMatches($userAgent) || $this->ar->isAllowed($url);
     }
+
+    public function matchesExactly($userAgent)
+    {
+        return in_array(strtolower($userAgent), $this->ua->getMatches($userAgent));
+    }
 }

--- a/src/Robot/RobotsTxt.php
+++ b/src/Robot/RobotsTxt.php
@@ -82,6 +82,16 @@ class RobotsTxt
             return true;
         }
 
+        /** @var Record[] $exactMatches */
+        $exactMatches = array_filter($this->records, function(Record $r) use ($userAgent) {
+            return $r->matchesExactly($userAgent);
+        });
+
+        if (!empty($exactMatches)) {
+            $firstMatch = array_shift($exactMatches);
+            return $firstMatch->isAllowed($userAgent, $path);
+        }
+
         $matching = array_filter($this->records, function(Record $r) use ($userAgent) {
             return $r->matches($userAgent);
         });

--- a/tests/RecordTest.php
+++ b/tests/RecordTest.php
@@ -54,4 +54,17 @@ class RecordTest extends \PHPUnit_Framework_TestCase
         $googleOnly = new Record(new UserAgent(['Googlebot']), new AccessRules([]));
         $this->assertTrue($googleOnly->getMatchStrength('G') == 9, 'Length of the matched UA is the strength');
     }
+
+    /**
+     * @test
+     */
+    public function givenExactMatch_flagAsBeingExact()
+    {
+        $googleOnly = new Record(new UserAgent(['Googlebot']), new AccessRules([]));
+        $this->assertTrue($googleOnly->matchesExactly('Googlebot'));
+        $this->assertTrue($googleOnly->matchesExactly('googlebot'));
+
+        $this->assertFalse($googleOnly->matchesExactly('google'));
+        $this->assertFalse($googleOnly->matchesExactly('googlebot-news'));
+    }
 }

--- a/tests/RobotTest.php
+++ b/tests/RobotTest.php
@@ -141,7 +141,11 @@ class RobotTest extends \PHPUnit_Framework_TestCase
         $this->assertRfcExample('/org/plans.html', [$webcrawler, $excite], [$unhipBot, $other]);
         $this->assertRfcExample('/%7Ejim/jim.html', [$webcrawler, $excite], [$unhipBot, $other]);
         $this->assertRfcExample('/%7Emak/mak.html', [$webcrawler, $excite, $other], [$unhipBot]);
+    }
 
-
+    public function testExactMatchesBeatPartial()
+    {
+        $this->assertTrue(self::getRobotsTxt('match')->isAllowed('Googlebot-News', '/'));
+        $this->assertTrue(self::getRobotsTxt('match')->isDisallowed('Googlebot', '/'));
     }
 } 

--- a/tests/files/match.txt
+++ b/tests/files/match.txt
@@ -1,0 +1,5 @@
+User-Agent: Googlebot
+Disallow: /
+
+User-Agent: Googlebot-News
+Allow: /


### PR DESCRIPTION
The [Google robots precedence rules](https://developers.google.com/webmasters/control-crawl-index/docs/robots_txt#order-of-precedence-for-user-agents) say:

> The crawler must determine the correct group of records by finding the group with the most specific user-agent that still matches. All other groups of records are ignored by the crawler. The user-agent is non-case-sensitive. All non-matching text is ignored (for example, both googlebot/1.2 and googlebot* are equivalent to googlebot).

This doesn't explicitly say that if your user agent is `Googlebot `then you should prefer a set of rules with the UA `Googlebot `over a set of rules with the UA `Googlebot-News` but the example they show demonstrates that behaviour, so this is a fix for exact UA matches not being prioritised over partial matches.