### PR TITLE
URL paths in robots.txt are case sensitive

### DIFF
--- a/src/Robot/RobotsFile.php
+++ b/src/Robot/RobotsFile.php
@@ -22,7 +22,7 @@ class RobotsFile implements \Iterator
      */
     public function __construct($content)
     {
-        $withoutComments = preg_replace( '/#.*/', '', strtolower($content));
+        $withoutComments = preg_replace( '/#.*/', '', $content);
         $lines = [];
 
         foreach(preg_split("/[\r\n]+/", $withoutComments) as $line) {

--- a/src/Robot/RobotsTxt.php
+++ b/src/Robot/RobotsTxt.php
@@ -42,7 +42,8 @@ class RobotsTxt
         $lastDirective = '';
 
         foreach($robotFile as $directive => $value) {
-
+            $directive = strtolower($directive);
+            
             // add a new record if we have the beginning of a new set of UAs
             if ($directive == self::USER_AGENT && $lastDirective != $directive) {
                 $fileRecords[] = $emptyRecord;

--- a/tests/RobotTest.php
+++ b/tests/RobotTest.php
@@ -158,4 +158,17 @@ class RobotTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($g->isAllowed('Googlebot-Images', '/bot'));
         $this->assertTrue($g->isDisallowed('Googlebot-Images', '/news'));
     }
-} 
+
+    public function testCaseSensitivePaths()
+    {
+        $g = self::getRobotsTxt('caseSensitive');
+        $this->assertFalse($g->isAllowed('Googlebot', '/lowercase.html'));
+        $this->assertTrue($g->isAllowed('Googlebot', '/LOWERCASE.HTML'));
+
+        $this->assertTrue($g->isAllowed('Googlebot', '/camelcase.html'));
+        $this->assertFalse($g->isAllowed('Googlebot', '/CamelCase.html'));
+
+        $this->assertTrue($g->isAllowed('Googlebot', '/uppercase.html'));
+        $this->assertFalse($g->isAllowed('Googlebot', '/UPPERCASE.HTML'));
+    }
+}

--- a/tests/RobotsFileTest.php
+++ b/tests/RobotsFileTest.php
@@ -27,8 +27,8 @@ class RobotsFileTest extends \PHPUnit_Framework_TestCase
     public function givenCrOnlyLineBreaks_pickUpTwoLines($newline)
     {
         $test = $this->getTestFile($newline);
-        $this->assertEquals(['user-agent', '*'], [$test->key(), $test->current()]);
+        $this->assertEquals(['User-Agent', '*'], [$test->key(), $test->current()]);
         $test->next();
-        $this->assertEquals(['disallow', '/'], [$test->key(), $test->current()]);
+        $this->assertEquals(['Disallow', '/'], [$test->key(), $test->current()]);
     }
 }

--- a/tests/files/caseSensitive.txt
+++ b/tests/files/caseSensitive.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /lowercase.html
+Disallow: /CamelCase.html
+Disallow: /UPPERCASE.HTML
+Allow: /


### PR DESCRIPTION
Instead of applying the `strtolower` on the entire contents of the post in `class RobotsFile` it should be applied to the directives when parsing individual lines in `class RobotsTxt`

This way url paths in the file that are case sensitive will be properly matched when comparing existing urls that contain case