### PR TITLE
invalid User-Agent causes strpos needle E_NOTICE

### DIFF
--- a/src/Robot/RobotsTxt.php
+++ b/src/Robot/RobotsTxt.php
@@ -65,6 +65,9 @@ class RobotsTxt
 
         $this->records = [];
         foreach($fileRecords as $record) {
+            if (!empty($record['ua'])) {
+                $record['ua'] = array_filter($record['ua']);
+            }
             if (!empty($record['ua']) && !empty($record['rules'])) {
                 $this->records[] = new Record(new UserAgent($record['ua']), new AccessRules($record['rules']));
             }

--- a/tests/RobotTest.php
+++ b/tests/RobotTest.php
@@ -171,4 +171,22 @@ class RobotTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($g->isAllowed('Googlebot', '/uppercase.html'));
         $this->assertFalse($g->isAllowed('Googlebot', '/UPPERCASE.HTML'));
     }
+
+    /**
+     * Do not emit an E_NOTICE with an empty needle from strpos when a user-agent line is invalid (empty).
+     * This effectively ignores the line.
+     */
+    public function testHandlesEmptyUserAgentLine()
+    {
+        $invalid_text = <<<EOF
+User-agent: foo
+User-agent:
+Disallow: /
+EOF;
+
+        $g = new RobotsTxt($invalid_text);
+
+        $this->assertFalse($g->isAllowed('foo', '/something'));
+        $this->assertTrue($g->isAllowed('Googlebot', '/something'));
+    }
 }


### PR DESCRIPTION
Some sites we encounter have invalid robots.txt files - e.g. https://www.fairtrade.org.uk/robots.txt which has : ```
User-agent:
Disallow: /```

This PR skips empty User-Agent line(s), which should stop the UserAgent class warning like : 

```
PHP Warning:  strpos(): Empty needle in /....../vendor/tomverran/robots-txt-checker/src/Robot/UserAgent.php on line 25
```
I don't know whether it should assume following rules belong to the previous valid User-Agent line.
