### PR TITLE
fix: Deprecated: Using ${var} in strings is deprecated, use {$var} ....

### DIFF
--- a/src/Robot/AccessRules.php
+++ b/src/Robot/AccessRules.php
@@ -25,7 +25,7 @@ class AccessRules
         }, explode('*', $pathWithoutTrailingDollar)));
 
         $trailingDollar = $path == $pathWithoutTrailingDollar ? '' : '$';
-        return "#^${quotedWithWildcards}{$trailingDollar}#";
+        return "#^{$quotedWithWildcards}{$trailingDollar}#";
     }
 
     private function urlDecodeNonSlashes($str)


### PR DESCRIPTION
 Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ..../tomverran/robots-txt-checker/src/Robot/AccessRules.php on line 28